### PR TITLE
v1.0.7

### DIFF
--- a/at.go
+++ b/at.go
@@ -37,7 +37,14 @@ func ParseAttributeType(raw string) (at AttributeType, err error) {
 		return
 	}
 
-	err = at.process(i.P.AttributeTypeDescription())
+	// Ensure what went in matches precisely what came out
+	x := i.P.AttributeTypeDescription()
+	if err = at.process(x); err == nil {
+		ptext := x.GetText()
+		if raw != ptext {
+			err = errorf("Inconsistent %T parse results or bad content", at)
+		}
+	}
 
 	return
 
@@ -86,7 +93,7 @@ func (r *AttributeType) process(ctx IAttributeTypeDescriptionContext) (err error
 	}
 
 	if len(r.OID) == 0 && len(r.Macro) == 0 {
-                err = errorf("Neither OID nor Macro literals found in %T", r)
+		err = errorf("Neither OID nor Macro literals found in %T", r)
 	}
 
 	return
@@ -98,7 +105,7 @@ func (r *AttributeType) setMisc(ctx any) (err error) {
 	case *NameContext:
 		r.Name, err = nameContext(tv.Names())
 	case *UsageContext:
-		r.Usage = trimL(tv.GetText(),` USAGE `)
+		r.Usage = trimL(tv.GetText(), ` USAGE `)
 	case *DescriptionContext:
 		r.Desc, err = descContext(tv)
 	case *ExtensionsContext:

--- a/dc.go
+++ b/dc.go
@@ -25,14 +25,20 @@ type DITContentRules []DITContentRule
 ParseDITContentRule processes raw into an instance of [DITContentRule],
 which is returned alongside an error.
 */
-func ParseDITContentRule(raw string) (oc DITContentRule, err error) {
+func ParseDITContentRule(raw string) (dc DITContentRule, err error) {
 	var i Instance
 	if i, err = ParseInstance(raw); err != nil {
 		return
 	}
 
-	err = oc.process(i.P.DITContentRuleDescription())
-
+	// Ensure what went in matches precisely what came out
+	x := i.P.DITContentRuleDescription()
+	if err = dc.process(x); err == nil {
+		ptext := x.GetText()
+		if raw != ptext {
+			err = errorf("Inconsistent %T parse results or bad content", dc)
+		}
+	}
 	return
 
 }

--- a/ds_test.go
+++ b/ds_test.go
@@ -18,3 +18,17 @@ func TestDITStructureRule(t *testing.T) {
 		}
 	}
 }
+
+func TestDITStructureRule_bogus(t *testing.T) {
+	crap := `( -1
+		NAME 'bogusRule'
+		FORM someForm
+		X-ORIGIN 'NOWHERE' )`
+
+	_, err := ParseDITStructureRule(crap)
+	if err == nil {
+		t.Errorf("%s failed: expected error, got nothing", t.Name())
+		return
+	}
+	//t.Logf("%#v\n", z)
+}

--- a/ls.go
+++ b/ls.go
@@ -7,7 +7,7 @@ LDAPSyntax implements RFC 4512 Section 4.1.5.
 */
 type LDAPSyntax struct {
 	OID        string
-	Macro	   []string
+	Macro      []string
 	Desc       string
 	Extensions map[string][]string
 }
@@ -34,7 +34,14 @@ func ParseLDAPSyntax(raw string) (ls LDAPSyntax, err error) {
 	}
 	ls = newLDAPSyntax()
 
-	err = ls.process(i.P.LDAPSyntaxDescription())
+	// Ensure what went in matches precisely what came out
+	x := i.P.LDAPSyntaxDescription()
+	if err = ls.process(x); err == nil {
+		ptext := x.GetText()
+		if raw != ptext {
+			err = errorf("Inconsistent %T parse results or bad content", ls)
+		}
+	}
 
 	return
 
@@ -79,4 +86,3 @@ func (r *LDAPSyntax) setMisc(ctx any) (err error) {
 
 	return
 }
-

--- a/mu.go
+++ b/mu.go
@@ -5,7 +5,7 @@ MatchingRuleUse implements RFC 4512 Section 4.1.4.
 */
 type MatchingRuleUse struct {
 	OID        string
-	Macro	   []string
+	Macro      []string
 	Name       []string
 	Desc       string
 	Obsolete   bool
@@ -40,7 +40,14 @@ func ParseMatchingRuleUse(raw string) (mu MatchingRuleUse, err error) {
 		return
 	}
 
-	err = mu.process(i.P.MatchingRuleUseDescription())
+	// Ensure what went in matches precisely what came out
+	x := i.P.MatchingRuleUseDescription()
+	if err = mu.process(x); err == nil {
+		ptext := x.GetText()
+		if raw != ptext {
+			err = errorf("Inconsistent %T parse results or bad content", mu)
+		}
+	}
 
 	return
 
@@ -53,8 +60,8 @@ func (r *MatchingRuleUse) process(ctx IMatchingRuleUseDescriptionContext) (err e
 
 	for k, ct := 0, ctx.GetChildCount(); k < ct && err == nil; k++ {
 		switch tv := ctx.GetChild(k).(type) {
-                case *NumericOIDOrMacroContext:                         
-                        r.OID, r.Macro, err = numOIDContext(tv)  
+		case *NumericOIDOrMacroContext:
+			r.OID, r.Macro, err = numOIDContext(tv)
 
 		case *NameContext,
 			*ExtensionsContext,

--- a/nf.go
+++ b/nf.go
@@ -30,16 +30,23 @@ func ParseNameForm(raw string) (nf NameForm, err error) {
 		return
 	}
 
-	err = nf.process(i.P.NameFormDescription())
+	// Ensure what went in matches precisely what came out
+	x := i.P.NameFormDescription()
+	if err = nf.process(x); err == nil {
+		ptext := x.GetText()
+		if raw != ptext {
+			err = errorf("Inconsistent %T parse results or bad content", nf)
+		}
+	}
 
 	return
 
 }
 
 func (r *NameForm) process(ctx INameFormDescriptionContext) (err error) {
-        if err = parenContext(ctx.OpenParen(), ctx.CloseParen()); err != nil {
-                return                                                  
-        }
+	if err = parenContext(ctx.OpenParen(), ctx.CloseParen()); err != nil {
+		return
+	}
 
 	for k, ct := 0, ctx.GetChildCount(); k < ct && err == nil; k++ {
 		switch tv := ctx.GetChild(k).(type) {
@@ -114,9 +121,9 @@ func (r *NameForm) mustContext(ctx *MustContext) (err error) {
 		if x := ctx.OID(); x != nil {
 			n, d, err = oIDContext(x.(*OIDContext))
 		} else if y := ctx.OIDs(); y != nil {
-                        if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
-                                return
-                        }
+			if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
+				return
+			}
 			n, d, err = oIDsContext(y.(*OIDsContext))
 		}
 
@@ -147,9 +154,9 @@ func (r *NameForm) mayContext(ctx *MayContext) (err error) {
 		if x := ctx.OID(); x != nil {
 			n, d, err = oIDContext(x.(*OIDContext))
 		} else if y := ctx.OIDs(); y != nil {
-                        if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
-                                return
-                        }
+			if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
+				return
+			}
 			n, d, err = oIDsContext(y.(*OIDsContext))
 		}
 

--- a/oc.go
+++ b/oc.go
@@ -31,16 +31,23 @@ func ParseObjectClass(raw string) (oc ObjectClass, err error) {
 		return
 	}
 
-	err = oc.process(i.P.ObjectClassDescription())
+	// Ensure what went in matches precisely what came out
+	x := i.P.ObjectClassDescription()
+	if err = oc.process(x); err == nil {
+		ptext := x.GetText()
+		if raw != ptext {
+			err = errorf("Inconsistent %T parse results or bad content", oc)
+		}
+	}
 
 	return
 
 }
 
 func (r *ObjectClass) process(ctx IObjectClassDescriptionContext) (err error) {
-        if err = parenContext(ctx.OpenParen(), ctx.CloseParen()); err != nil {
-                return                                                  
-        }
+	if err = parenContext(ctx.OpenParen(), ctx.CloseParen()); err != nil {
+		return
+	}
 
 	for k, ct := 0, ctx.GetChildCount(); k < ct && err == nil; k++ {
 		switch tv := ctx.GetChild(k).(type) {
@@ -77,7 +84,7 @@ func (r *ObjectClass) process(ctx IObjectClassDescriptionContext) (err error) {
 	}
 
 	if len(r.OID) == 0 && len(r.Macro) == 0 {
-                err = errorf("Neither OID nor Macro literals found in %T", r)
+		err = errorf("Neither OID nor Macro literals found in %T", r)
 	}
 
 	return
@@ -117,9 +124,9 @@ func (r *ObjectClass) superClassesContext(ctx *SuperClassesContext) (err error) 
 		if x := ctx.OID(); x != nil {
 			n, d, err = oIDContext(x.(*OIDContext))
 		} else if y := ctx.OIDs(); y != nil {
-                        if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
-                                return
-                        }
+			if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
+				return
+			}
 			n, d, err = oIDsContext(y.(*OIDsContext))
 		}
 
@@ -150,9 +157,9 @@ func (r *ObjectClass) mustContext(ctx *MustContext) (err error) {
 		if x := ctx.OID(); x != nil {
 			n, d, err = oIDContext(x.(*OIDContext))
 		} else if y := ctx.OIDs(); y != nil {
-                        if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
-                                return
-                        }
+			if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
+				return
+			}
 			n, d, err = oIDsContext(y.(*OIDsContext))
 		}
 
@@ -183,9 +190,9 @@ func (r *ObjectClass) mayContext(ctx *MayContext) (err error) {
 		if x := ctx.OID(); x != nil {
 			n, d, err = oIDContext(x.(*OIDContext))
 		} else if y := ctx.OIDs(); y != nil {
-                        if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
-                                return
-                        }
+			if err = parenContext(y.OpenParen(), y.CloseParen()); err != nil {
+				return
+			}
 			n, d, err = oIDsContext(y.(*OIDsContext))
 		}
 

--- a/schema.go
+++ b/schema.go
@@ -119,30 +119,30 @@ func (r *Schema) ParseRaw(raw []byte) (err error) {
 		return
 	}
 
-        var i Instance                                                  
-        if i, err = ParseInstance(string(raw)); err != nil {        
-                return                                                  
-        }                                                               
-                                                                        
-        fp := i.P.Fileparse()                                           
-                                                                        
-        defs := fp.Definitions()                                        
-        if defs == nil {                                                
-                err = errorf("No definitions found in %T", defs)        
-                return                                                  
-        }                                                               
-                                                                        
-        r.processObjectIdentifiers(defs.AllObjectIdentifier())          
-                                                                        
-        if dn := fp.SchemaDN(); dn != nil && len(r.DN) == 0 {           
-                r.DN = trimS(trimL(dn.GetText(), `dn:`))                
-        }                                                               
-                                                                        
-        if err = r.processSchemaDefinitions(defs); err == nil {         
-                r.UpdateMatchingRuleUses()                              
-        }                                                               
-                                                                        
-        return
+	var i Instance
+	if i, err = ParseInstance(string(raw)); err != nil {
+		return
+	}
+
+	fp := i.P.Fileparse()
+
+	defs := fp.Definitions()
+	if defs == nil {
+		err = errorf("No definitions found in %T", defs)
+		return
+	}
+
+	r.processObjectIdentifiers(defs.AllObjectIdentifier())
+
+	if dn := fp.SchemaDN(); dn != nil && len(r.DN) == 0 {
+		r.DN = trimS(trimL(dn.GetText(), `dn:`))
+	}
+
+	if err = r.processSchemaDefinitions(defs); err == nil {
+		r.UpdateMatchingRuleUses()
+	}
+
+	return
 }
 
 /*


### PR DESCRIPTION
## Changes

  - Resolve subtle error ignorance in parsed content
    - Cases where ANTLR grammar is unable to detect issues -- such as negative numbers where only unsigned numbers should reside -- are now flagged for error
    - Resulting strings processed by ANTLR are now compared to the original, sans WHSP and/or newline considerations